### PR TITLE
MergedModifierStack will now call OnPoolItems for all GoModifiers when Tile Unregisters.

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -3,8 +3,10 @@
 ### Bug Fixes
 - Fixes a bug where add collider feature didn't work for flat terrain mesh.
 - Fix a bug where vector tile processing fired multiple times depending on Terrain/Image data states
+
 ### Improvements
 - Improves Directions factory and prefabs to provide better UX and support for all types of maps
+- OnPoolItem is now called for all GoModifiers in the MergedModifierStack.
 
 ### v2.1.1
 10/15/2019

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MergedModifierStack.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Modifiers/MergedModifierStack.cs
@@ -64,6 +64,11 @@ namespace Mapbox.Unity.MeshGeneration.Modifiers
 				_counter = _activeObjects[tile].Count;
 				for (int i = 0; i < _counter; i++)
 				{
+					//TODO Added this bit, to call on pool items for MergedModifierStack
+					foreach (var item in GoModifiers)
+					{
+						item.OnPoolItem(_activeObjects[tile][i]);
+					}
 					if (null != _activeObjects[tile][i].GameObject)
 					{
 						_activeObjects[tile][i].GameObject.SetActive(false);


### PR DESCRIPTION
**Related issue**

Relates to https://github.com/mapbox/mapbox-unity-sdk/issues/1455

**Description of changes**

Call `OnPoolItem` in MergedModifierStack for all GameObjectModifiers

**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [x] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [x] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
