### PR TITLE
Fix IndexOutOfRangeException when clicking on Map tile in editor due to empty Height Data.

### DIFF
--- a/documentation/docs/05-changelog.md
+++ b/documentation/docs/05-changelog.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 - Fixes a bug where add collider feature didn't work for flat terrain mesh.
 - Fix a bug where vector tile processing fired multiple times depending on Terrain/Image data states
+- Fix IndexOutOfRangeException when clicking on Map tile in editor due to empty Height Data.
 ### Improvements
 - Improves Directions factory and prefabs to provide better UX and support for all types of maps
 

--- a/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
+++ b/sdkproject/Assets/Mapbox/Unity/MeshGeneration/Data/UnityTile.cs
@@ -327,7 +327,7 @@ namespace Mapbox.Unity.MeshGeneration.Data
 		/// <returns></returns>
 		public float QueryHeightData(float x, float y)
 		{
-			if (HeightData != null)
+			if (HeightData != null && HeightData.Length > 0)
 			{
 				return HeightData[(int)(Mathf.Clamp01(y) * 255) * 256 + (int)(Mathf.Clamp01(x) * 255)] * _tileScale;
 			}
@@ -345,7 +345,7 @@ namespace Mapbox.Unity.MeshGeneration.Data
 		/// <returns></returns>
 		public float QueryHeightDataNonclamped(float x, float y)
 		{
-			if (HeightData != null)
+			if (HeightData != null && HeightData.Length > 0)
 			{
 				return HeightData[(int)(y * 255) * 256 + (int)(x * 255)] * _tileScale;
 			}


### PR DESCRIPTION
**Related issue**

Example: 

When clicking on a tile in the Map GameObject in Unity an `IndexOutOfRangeException` is thrown due to instantiated empty HeightData.

![image](https://user-images.githubusercontent.com/2967721/133524464-23060c52-efc3-47c1-a320-fbc39fbe4dbe.png)

**Description of changes**

Additionally check if HeightData is empty in `QueryHeightData` and `QueryHeightDataNonClamped` to account for inspector empty initialization.

**QA checklists**

- [x] Add relevant code comments. Every API class and method should have `<summary>` description as well as description of parameters.
- [x] **Add tests for new/changed/updated classes and methods!!!**
- [x] Check out conventions in [CONTRIBUTING.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CONTRIBUTING.md).
- [x] Check out conventions in [CODING-STYLE.md](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/CODING-STYLE.md)
- [x] Update the [changelog](https://github.com/mapbox/mapbox-unity-sdk/blob/develop/documentation/docs/05-changelog.md)
- [x] Update documentation.

**Reviewers**

Tag your reviewer(s). Choose wisely.
